### PR TITLE
🔧 Migrate to Arcane Engine SDK

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,7 +6,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <type id="django" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" project-jdk-name="Poetry (pr-pilot-cli)" project-jdk-type="Python SDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" project-jdk-name="Poetry (cli)" project-jdk-type="Python SDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/cli/commands/history.py
+++ b/cli/commands/history.py
@@ -1,5 +1,6 @@
 import click
-from pr_pilot.util import list_tasks
+from arcane.engine import ArcaneEngine
+
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.padding import Padding
@@ -16,7 +17,8 @@ You have no tasks yet. Run a task with `pilot task` to create one.
 @click.pass_context
 def history(ctx):
     """📜 Access recent tasks."""
-    tasks = list_tasks()
+    engine = ArcaneEngine()
+    tasks = engine.list_tasks()
     ctx.obj["tasks"] = tasks
 
     if ctx.invoked_subcommand is None:

--- a/cli/commands/pr.py
+++ b/cli/commands/pr.py
@@ -1,10 +1,11 @@
 import webbrowser
 
+import arcane
 import click
-import pr_pilot
-from pr_pilot import RepoBranchInput
-from pr_pilot.exceptions import NotFoundException
-from pr_pilot.util import _get_config_from_env
+from arcane import RepoBranchInput
+from arcane.exceptions import NotFoundException
+from arcane.util import _get_config_from_env
+
 from rich.console import Console
 
 from cli.detect_repository import detect_repository
@@ -33,8 +34,8 @@ def pr(ctx, no_browser):
     status_indicator.start()
 
     # Retrieve the PR number
-    with pr_pilot.ApiClient(_get_config_from_env()) as api_client:
-        api_instance = pr_pilot.PRRetrievalApi(api_client)
+    with arcane.ApiClient(_get_config_from_env()) as api_client:
+        api_instance = arcane.PRRetrievalApi(api_client)
         if not repo:
             raise Exception("Repository not found.")
         try:

--- a/cli/prompt_template.py
+++ b/cli/prompt_template.py
@@ -4,7 +4,7 @@ import subprocess
 import click
 import inquirer
 import jinja2
-from pr_pilot.util import create_task
+from arcane.engine import ArcaneEngine
 from rich.console import Console
 from rich.padding import Padding
 from rich.prompt import Prompt
@@ -136,7 +136,8 @@ class PromptTemplate:
 
             try:
                 status.update_spinner_message("Creating sub-task ...")
-                task = create_task(self.repo, prompt, log=False, gpt_model=self.model)
+                engine = ArcaneEngine()
+                task = engine.create_task(self.repo, prompt, log=False, gpt_model=self.model)
                 task_handler = TaskHandler(task, status)
                 return task_handler.wait_for_result(log_messages=False, print_result=False)
             except Exception as e:

--- a/cli/task_handler.py
+++ b/cli/task_handler.py
@@ -3,7 +3,7 @@ import json
 
 import click.exceptions
 import websockets
-from pr_pilot import Task
+from arcane import Task
 from rich.console import Console
 from websockets.frames import CloseCode
 

--- a/cli/task_runner.py
+++ b/cli/task_runner.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from typing import Optional
 
 import click
-from pr_pilot import Task, ApiException
-from pr_pilot.util import create_task
+from arcane import Task, ApiException
+from arcane.engine import ArcaneEngine
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.padding import Padding
@@ -94,7 +94,8 @@ class TaskRunner:
             else ""
         )
         try:
-            task = create_task(
+            engine = ArcaneEngine()
+            task = engine.create_task(
                 params.repo,
                 params.prompt,
                 log=False,

--- a/cli/util.py
+++ b/cli/util.py
@@ -4,7 +4,7 @@ import subprocess
 from datetime import datetime, timezone
 
 import humanize
-from pr_pilot import Task
+from arcane import Task
 from rich import box
 from rich.markdown import Markdown
 from rich.panel import Panel

--- a/poetry.lock
+++ b/poetry.lock
@@ -23,6 +23,23 @@ files = [
 ]
 
 [[package]]
+name = "arcane-engine"
+version = "1.8.0"
+description = "Python SDK for Arcane Engine, a text-to-task automation platform."
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "arcane_engine-1.8.0-py3-none-any.whl", hash = "sha256:e4f174f0379f6a9c829ebb246007b6fbc0eef12ad2c043547991384ba8b73e84"},
+    {file = "arcane_engine-1.8.0.tar.gz", hash = "sha256:b0054edda3489e3fbb8b26e6cc5abce1413d51fff832b723139084cf4dad50fb"},
+]
+
+[package.dependencies]
+pydantic = "<2.7"
+python-dateutil = "2.9.0"
+urllib3 = "2.2.1"
+wheel = "0.42.0"
+
+[[package]]
 name = "black"
 version = "24.8.0"
 description = "The uncompromising code formatter."
@@ -162,19 +179,19 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
-version = "3.15.4"
+version = "3.16.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.15.4-py3-none-any.whl", hash = "sha256:6ca1fffae96225dab4c6eaf1c4f4f28cd2568d3ec2a44e15a08520504de468e7"},
-    {file = "filelock-3.15.4.tar.gz", hash = "sha256:2207938cbc1844345cb01a5a95524dae30f0ce089eba5b00378295a17e3e90cb"},
+    {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
+    {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-asyncio (>=0.21)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)", "virtualenv (>=20.26.2)"]
-typing = ["typing-extensions (>=4.8)"]
+docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4.1)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.2)", "pytest (>=8.3.3)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.4)"]
+typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
 name = "flake8"
@@ -208,13 +225,13 @@ tests = ["freezegun", "pytest", "pytest-cov"]
 
 [[package]]
 name = "identify"
-version = "2.6.0"
+version = "2.6.1"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "identify-2.6.0-py2.py3-none-any.whl", hash = "sha256:e79ae4406387a9d300332b5fd366d8994f1525e8414984e1a59e058b2eda2dd0"},
-    {file = "identify-2.6.0.tar.gz", hash = "sha256:cb171c685bdc31bcc4c1734698736a7d5b6c8bf2e0c15117f4d469c8640ae5cf"},
+    {file = "identify-2.6.1-py2.py3-none-any.whl", hash = "sha256:53863bcac7caf8d2ed85bd20312ea5dcfc22226800f6d6881f232d861db5a8f0"},
+    {file = "identify-2.6.1.tar.gz", hash = "sha256:91478c5fb7c3aac5ff7bf9b4344f803843dc586832d5f110d672b19aa1984c98"},
 ]
 
 [package.extras]
@@ -439,19 +456,19 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.2.2"
+version = "4.3.6"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.2.2-py3-none-any.whl", hash = "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee"},
-    {file = "platformdirs-4.2.2.tar.gz", hash = "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"},
+    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
+    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
-type = ["mypy (>=1.8)"]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.11.2)"]
 
 [[package]]
 name = "pluggy"
@@ -467,23 +484,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "pr-pilot"
-version = "1.7.0"
-description = "Python SDK for PR Pilot, a text-to-task automation platform for Github."
-optional = false
-python-versions = ">=3.10"
-files = [
-    {file = "pr_pilot-1.7.0-py3-none-any.whl", hash = "sha256:4f19f52965b6ef71d60baa3df34c3f0a59a3616889300321902a312370cfef48"},
-    {file = "pr_pilot-1.7.0.tar.gz", hash = "sha256:00eac0847ea91fc207ab0168fc43b3ae8be961357e85423566aac591387a690b"},
-]
-
-[package.dependencies]
-pydantic = "<2.7"
-python-dateutil = "2.9.0"
-urllib3 = "2.2.1"
-wheel = "0.42.0"
 
 [[package]]
 name = "pre-commit"
@@ -651,13 +651,13 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.3.2"
+version = "8.3.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.3.2-py3-none-any.whl", hash = "sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5"},
-    {file = "pytest-8.3.2.tar.gz", hash = "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce"},
+    {file = "pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2"},
+    {file = "pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181"},
 ]
 
 [package.dependencies]
@@ -854,13 +854,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.26.3"
+version = "20.26.5"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.26.3-py3-none-any.whl", hash = "sha256:8cc4a31139e796e9a7de2cd5cf2489de1217193116a8fd42328f1bd65f434589"},
-    {file = "virtualenv-20.26.3.tar.gz", hash = "sha256:4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a"},
+    {file = "virtualenv-20.26.5-py3-none-any.whl", hash = "sha256:4f3ac17b81fba3ce3bd6f4ead2749a72da5929c01774948e243db9ba41df4ff6"},
+    {file = "virtualenv-20.26.5.tar.gz", hash = "sha256:ce489cac131aa58f4b25e321d6d186171f78e6cb13fafbf32a840cee67733ff4"},
 ]
 
 [package.dependencies]
@@ -1006,4 +1006,4 @@ termcolor = "2.3.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.0"
-content-hash = "0522db7eb1fa97ccc80bc040d441d049e018788509ce3e3d2ebe0562b4a91778"
+content-hash = "39a36baceca9f02de92c7662e961f7a829fc4f2f9c0c4a4f48efb7bca5abe293"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [tool.poetry]
 name = "pr-pilot-cli"
-version = "1.19.3"
+version = "1.20.0"
 description = "CLI for PR Pilot, a text-to-task automation platform."
-authors = ["Marco Lamina <marco@pr-pilot.ai>"]
+authors = ["Marco Lamina <marco@arcane.engineer>"]
 license = "GPL-3.0"
 readme = "README.md"
 packages = [{include = "cli"}]
 documentation = "https://docs.pr-pilot.ai"
 homepage = "https://www.pr-pilot.ai"
-repository = "https://github.com/pr-pilot-ai/pr-pilot-cli"
+repository = "https://github.com/arc-eng/cli"
 
 [tool.black]
 line-length = 100
@@ -16,7 +16,7 @@ line-length = 100
 [tool.poetry.dependencies]
 python = "~3.10.0"
 click = "8.1.7"
-pr-pilot = "1.7.0"
+arcane-engine = "1.8.0"
 pyyaml = "6.0.1"
 yaspin = "3.0.2"
 rich = "13.7.1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,13 @@ def mock_user_config(mock_default_config_location):
 
 
 @pytest.fixture(autouse=True)
+def mock_engine_in_history_command():
+    with patch("cli.commands.history.ArcaneEngine") as mock:
+        mock.return_value = MagicMock()
+        yield mock.return_value
+
+
+@pytest.fixture(autouse=True)
 def mock_console():
     with patch("cli.task_handler.Console") as mock:
         yield mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,12 +31,6 @@ def mock_user_config(mock_default_config_location):
 
 
 @pytest.fixture(autouse=True)
-def mock_list_tasks():
-    with patch("cli.commands.history.list_tasks") as mock:
-        yield mock
-
-
-@pytest.fixture(autouse=True)
 def mock_console():
     with patch("cli.task_handler.Console") as mock:
         yield mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,10 @@ def mock_default_config_location(tmp_path):
 
 
 @pytest.fixture(autouse=True)
-def mock_create_task():
-    with patch("cli.task_runner.create_task") as mock:
-        yield mock
+def mock_engine():
+    with patch("cli.task_runner.ArcaneEngine") as mock:
+        mock.return_value = MagicMock()
+        yield mock.return_value
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,13 +30,13 @@ def test_main_loads_user_config(mock_user_config, runner):
     assert result.exit_code == 0
 
 
-def test_code_param_includes_code_primer(runner, mock_create_task):
+def test_code_param_includes_code_primer(runner, mock_engine):
     """The --code param should include the code primer in the prompt"""
     prompt = "This is a test prompt."
     result = runner.invoke(main, ["task", "--code", prompt])
 
-    mock_create_task.assert_called_once()
-    called_prompt = mock_create_task.call_args[0][1]
+    mock_engine.create_task.assert_called_once()
+    called_prompt = mock_engine.create_task.call_args[0][1]
     assert CODE_PRIMER in called_prompt
     assert prompt in called_prompt
     assert result.exit_code == 0
@@ -56,7 +56,7 @@ def mock_click_prompt():
 
 
 def test_save_command_param_saves_command(
-    runner, mock_create_task, mock_command_index, mock_click_prompt
+    runner, mock_engine, mock_command_index, mock_click_prompt
 ):
     """The --save-command param should save the task parameters as a command"""
     prompt = "This is a test prompt."
@@ -66,11 +66,11 @@ def test_save_command_param_saves_command(
 
 
 def test_save_command_param_does_not_run_task(
-    runner, mock_create_task, mock_command_index, mock_click_prompt
+    runner, mock_engine, mock_command_index, mock_click_prompt
 ):
     """The --save-command param should not run the task"""
     result = runner.invoke(main, ["task", "--save-command", "test-prompt"])
-    mock_create_task.assert_not_called()
+    mock_engine.assert_not_called()
     assert result.exit_code == 0
 
 
@@ -80,14 +80,14 @@ def test_sync_option_syncs_correctly(
     mock_pull_branch_changes,
     mock_get_branch_if_pushed,
     runner,
-    mock_create_task,
+        mock_engine,
 ):
     """The --sync option should set the branch to the current branch"""
     mock_get_branch_if_pushed.return_value = "test-value"
     result = runner.invoke(main, ["--wait", "--sync", "task", "test-prompt"])
-    mock_create_task.assert_called_once()
+    mock_engine.create_task.assert_called_once()
     mock_pull_branch_changes.assert_called_once()
-    assert mock_create_task.call_args[1]["branch"] == "test-value"
+    assert mock_engine.create_task.call_args[1]["branch"] == "test-value"
     assert result.exit_code == 0
 
 
@@ -97,10 +97,10 @@ def test_sync_option_syncs_only_pushed_branches(
     mock_pull_branch_changes,
     mock_get_branch_if_pushed,
     runner,
-    mock_create_task,
+        mock_engine,
 ):
     mock_get_branch_if_pushed.return_value = None
     result = runner.invoke(main, ["--wait", "--sync", "task", "test-prompt"])
-    mock_create_task.assert_called_once()
-    assert mock_create_task.call_args[1]["branch"] is None
+    mock_engine.create_task.assert_called_once()
+    assert mock_engine.create_task.call_args[1]["branch"] is None
     assert result.exit_code == 0

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import humanize
 import pytest
-from pr_pilot import Task
+from arcane import Task
 from rich.markdown import Markdown
 
 from cli.util import (


### PR DESCRIPTION
This PR migrates the project from PR Pilot SDK to the new Arcane Engine SDK, ensuring better performance and new features.

**Dependency Updates**
- Replace `pr-pilot` with `arcane-engine` in [pyproject.toml](https://github.com/arc-eng/cli/blob/arcane-engine/pyproject.toml) and [poetry.lock](https://github.com/arc-eng/cli/blob/arcane-engine/poetry.lock)
- Update various dependencies to their latest versions in [poetry.lock](https://github.com/arc-eng/cli/blob/arcane-engine/poetry.lock)

**Code Changes**
- Update import statements to use `arcane-engine` in [cli/prompt_template.py](https://github.com/arc-eng/cli/blob/arcane-engine/cli/prompt_template.py), [cli/task_runner.py](https://github.com/arc-eng/cli/blob/arcane-engine/cli/task_runner.py)
- Modify test fixtures and test cases to mock `ArcaneEngine` in [tests/conftest.py](https://github.com/arc-eng/cli/blob/arcane-engine/tests/conftest.py) and [tests/test_cli.py](https://github.com/arc-eng/cli/blob/arcane-engine/tests/test_cli.py)

**IDE Configuration**
- Update project SDK name in [.idea/misc.xml](https://github.com/arc-eng/cli/blob/arcane-engine/.idea/misc.xml)